### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DHT 	KEYWORD1
+DHT	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin				KEYWORD2
-read 				KEYWORD2
-getState			KEYWORD2
-getTemperatureC 	KEYWORD2
-getTemperatureK		KEYWORD2
-getTemperatureF		KEYWORD2
-getHumidity			KEYWORD2
+begin	KEYWORD2
+read	KEYWORD2
+getState	KEYWORD2
+getTemperatureC	KEYWORD2
+getTemperatureK	KEYWORD2
+getTemperatureF	KEYWORD2
+getHumidity	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-DHT_OK				LITERAL1
+DHT_OK	LITERAL1
 DHT_ERROR_CHECKSUM	LITERAL1
 DHT_ERROR_TIMEOUT	LITERAL1
 DHT_ERROR_NO_REPLY	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords